### PR TITLE
#638: 버그 픽스

### DIFF
--- a/Mohaeng/Mohaeng/Resources/Storyboards/Home/MyPage.storyboard
+++ b/Mohaeng/Mohaeng/Resources/Storyboards/Home/MyPage.storyboard
@@ -433,6 +433,8 @@
                         <outlet property="bgCircleView" destination="WIJ-GA-thH" id="yXX-pP-JQG"/>
                         <outlet property="calendarBgView" destination="m8j-Aj-SRl" id="3iQ-dK-JmP"/>
                         <outlet property="calendarCollectionView" destination="P0G-AX-9Lu" id="CpC-ZZ-xIK"/>
+                        <outlet property="calendarLeftButton" destination="BJD-yt-mGw" id="QPn-nl-iI7"/>
+                        <outlet property="calendarRightButton" destination="6Ix-AC-xOm" id="YbJ-aZ-fkJ"/>
                         <outlet property="calendarShadowView" destination="zNV-Cq-MZs" id="Oq6-8s-3RP"/>
                         <outlet property="completeChallengeCountLabel" destination="oz1-LL-JBv" id="DQQ-PV-S4z"/>
                         <outlet property="completeCourseCountLabel" destination="gVo-rS-84V" id="sCs-sE-wCz"/>

--- a/Mohaeng/Mohaeng/Sources/APIModels/Feed.swift
+++ b/Mohaeng/Mohaeng/Sources/APIModels/Feed.swift
@@ -16,7 +16,7 @@ struct FeedResponse: Codable {
 }
 
 // MARK: - Feed
-struct Feed: Codable {
+struct Feed: Codable, Equatable {
     let postID: Int
     let course: String
     let challenge: Int
@@ -33,6 +33,10 @@ struct Feed: Codable {
         case course, challenge, image, mood, content, nickname, year, month, emoji, myEmoji, isReport, isDelete
         case day = "date"
         case weekday = "day"
+    }
+    
+    static func == (lhs: Feed, rhs: Feed) -> Bool {
+        return lhs.postID == rhs.postID
     }
 }
 

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Feed/FeedDetailViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Feed/FeedDetailViewController.swift
@@ -214,7 +214,7 @@ extension FeedDetailViewController: UICollectionViewDelegateFlowLayout {
         let width: CGFloat = UIScreen.main.bounds.width
         let imageHeight: CGFloat = width
         var baseHeight: CGFloat = UIDevice.current.hasNotch ? (588 / 812) * UIScreen.main.bounds.height : 588
-        let maximumHeight: CGFloat = (672 / 812) * UIScreen.main.bounds.height
+        let maximumHeight: CGFloat = (800 / 812) * UIScreen.main.bounds.height
         let dummyCell = FeedDetailCollectionViewCell(frame: CGRect(x: 0, y: 0, width: width, height: maximumHeight))
         
         switch previousController {

--- a/Mohaeng/Mohaeng/Sources/ViewControllers/Home/Mypage/MyPageViewController.swift
+++ b/Mohaeng/Mohaeng/Sources/ViewControllers/Home/Mypage/MyPageViewController.swift
@@ -14,10 +14,13 @@ class MyPageViewController: UIViewController {
     var myPageData = MyPage(nickname: "", email: "", completeCourseCount: 0, completeChallengeCount: 0, feedCount: 0, badgeCount: 0, calendar: [
         MyPageCalendar(property: 1, date: [])
     ])
+    let currentDate = AppDate()
     
     // MARK: - @IBOutlet Properties
     
     @IBOutlet weak var calendarCollectionView: JTACMonthView!
+    @IBOutlet weak var calendarLeftButton: UIButton!
+    @IBOutlet weak var calendarRightButton: UIButton!
     @IBOutlet weak var bgCircleView: UIView!
     @IBOutlet weak var shadowStackView: UIStackView!
     @IBOutlet weak var summaryStackView: UIStackView!
@@ -40,8 +43,12 @@ class MyPageViewController: UIViewController {
     var frameDimensions: CGFloat = 0.00
     var selected = Date()
     var rangeDates = [[Date]]()
-    var currentSection: Int = 0
     var totalSectionCount: Int = 0
+    var currentSection: Int = 0 {
+        didSet {
+            hideArrowButton()
+        }
+    }
     
     // MARK: - View Life Cycle
 
@@ -241,8 +248,10 @@ class MyPageViewController: UIViewController {
             calendarCollectionView.scrollToItem(at: IndexPath.init(row: 0, section: currentSection), at: .left, animated: true)
         }
         
-        let month = 1 + currentSection
-        yearMonthLabel.text = "2021년 \(month)월"
+        let startYear = 2021
+        let selectedYear = (currentSection / 12) + startYear
+        let selectedMonth = (1 + currentSection) % 12
+        yearMonthLabel.text = "\(selectedYear)년 \(selectedMonth == 0 ? 12 : selectedMonth)월"
     }
     
     func setTotalSectionCount() {
@@ -261,7 +270,14 @@ class MyPageViewController: UIViewController {
         currentSection = totalSectionCount
         calendarCollectionView.scrollToItem(at: IndexPath.init(row: 0, section: currentSection), at: .left, animated: true)
         
-        yearMonthLabel.text = "2021년 \(totalSectionCount + 1)월"
+        let currentMonth = (totalSectionCount + 1) % 12
+        yearMonthLabel.text = "\(currentDate.getYear())년 \(currentMonth)월"
+    }
+    
+    // 2021년 1월 / 현재년월 캘린더일때 왼쪽, 오른쪽 버튼 숨김 처리
+    func hideArrowButton() {
+        calendarLeftButton.isHidden = currentSection == 0
+        calendarRightButton.isHidden = currentSection == totalSectionCount
     }
     
     // 통신 후 data 업데이트


### PR DESCRIPTION
안녕하세요 
갑작스런 떡상으로 인해 허버허버 버그 픽스합니다 ㅋ
시간 많은 제가 초이 버그도 픽스햇어요 

## bug 1 캘린더 날짜 버그
@iamcho2 2021년으로 해놓으셧더라고요 ㅋㅋ 만이 귀찮으셨나봅니다. 
바꾸면서 화살표 버튼 선택 안될때 (2021년 1월일 때 left Arrow랑 현재 년월 캘린더에서 right Arrow)는 슬쩍 숨김 처리 했어요
![image](https://user-images.githubusercontent.com/69361613/151515610-ae5819e9-fb23-410f-aae0-5c2a31395092.png)

## bug 2 se에서 짤림
글자수 제한이 풀리면서 se에서는 짤리나보더라고요
일단 임시방편 maximum 값 증가시켜놨구
이 부분 나중에 시간 날 때 통째로 코드 바꾸려고 합니돠..

## bud 3 피드 기타 버그
일단 페이징으로 인한 모종의 이유로 서버에서 피드 get해오는 걸 viewDidLoad 에 해놨었는데
이러니까 버그가 너무 많이 생겨서 일단 다시 돌려놨고 다시 돌려두면서 updateData 관련 함수 좀 바꿨습니다
기존 코드는 5번째까지 페이징한 상태에서 refresh 하면 버그가 있어서

1. 피드가 처음 로드될 때(contentOffset == 0) 원래 하는 것 처럼 allFeeds 함수에 셋팅
2. refresh Control로 새로고침 했을 때 (contentOffset < 0) 일 땐 새로 들어온 값, 삭제된 값 비교
(-> 사실 요 것도 문제가 있긴 한 데 refresh Control로 새고할 때는 0번째 페이지 get 해오도록 했는데 
만약 현재 페이징을 5번째 페이지까지 했다 치고 2~5번째 페이지에 있는 어떤 컨텐츠가 삭제되면 반영을 못함.
새고할 때 5번째 페이지까지 총 5번 get을 하도록 해야되는데 
이건 고치는 데에 시간이 많이 걸릴 것 같아서 0번째 페이지만 해놧어요 ㄱ-
걍 리프레시 컨트롤 없애버릴까 하다가..... 일딴 냅둠)
3. 그리고 페이징 중일 때는 새로 들어온 것만 append

로 나누었어요

걍.. 피드 삮 다 뜯어고치싶은데 엄두가 안남

resolve #638 